### PR TITLE
New strings on CS, DE, FR

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -1,6 +1,6 @@
 {
     "localeCode" : "cs",
-    "authors" : ["Frooxius", "rampa_3"],
+    "authors" : ["Frooxius", "rampa_3", "Pr3Ci510n"],
     "messages" : 
     {
         "General.OK" : "OK",

--- a/cs.json
+++ b/cs.json
@@ -625,6 +625,7 @@
         "Importer.Model.Advanced.Tangents" : "Spočítat Tangenty",
         "Importer.Model.Advanced.VertexColors" : "Importovat barvy vertexů",
         "Importer.Model.Advanced.Bones" : "Importovat bones",
+        "Importer.Model.Advanced.Lights" : "Importovat světlo",
         "Importer.Model.Advanced.TextureAlpha" : "Detekovat průhlednost textur",
         "Importer.Model.Advanced.AlbedoColor" : "Importovat albedo barvy",
         "Importer.Model.Advanced.ImportEmissive" : "Importovat emisivní barvy",

--- a/de.json
+++ b/de.json
@@ -1,6 +1,6 @@
 {
     "localeCode" : "de",
-    "authors" : ["Avunia", "Elektrospy", "MR-Alex", "Schwefelhexafluorid", "Blaze", "Tillikum", "Bluigi", "Ardes", "dfgHiatus"],
+    "authors" : ["Avunia", "Elektrospy", "MR-Alex", "Schwefelhexafluorid", "Blaze", "Tillikum", "Bluigi", "Ardes", "dfgHiatus", "Pr3Ci510n"],
     "messages" :
     {
         "General.OK" : "OK",
@@ -442,6 +442,7 @@
         "Tooltips.Dev.OpenInspector" : "Inspektor öffnen",
         "Tooltips.Dev.DeselectAll" : "Alles abwählen",
         "Tooltips.Dev.DestroySelected" : "Ausgewählte Objekte löschen",
+        "Tooltips.Dev.ConfirmDestroySelected" : "WIRKLICH Ausgewählte Objekte löschen",
 
         "Tooltip.Logix.NodeBrowser" : "Node-Browser",
         "Tooltip.Logix.UnpackChildren" : "Verbundene und Unterknoten entpacken",
@@ -624,6 +625,7 @@
         "Importer.Model.Advanced.Tangents" : "Tangenten berechnen",
         "Importer.Model.Advanced.VertexColors" : "Vertex-Farben importieren",
         "Importer.Model.Advanced.Bones" : "Bones importieren",
+        "Importer.Model.Advanced.Lights" : "Beleuchtung importieren",
         "Importer.Model.Advanced.TextureAlpha" : "Texture-Alpha berechnen",
         "Importer.Model.Advanced.AlbedoColor" : "Albedo-Texturen importieren",
         "Importer.Model.Advanced.ImportEmissive" : "Emissions-Texturen importieren",
@@ -643,6 +645,7 @@
         "Importer.Model.Advanced.FlatShaded" : "Flach schattieren",
         "Importer.Model.Advanced.DeduplicateInstances" : "Instanzen-Duplikate entfernen (langsam)",
         "Importer.Model.Advanced.Optimize" : "Modell/Szene optimieren",
+        "Importer.Model.Advanced.SplitSubmeshes" : "Submeshes aufteilen",
         "Importer.Model.Advanced.RandomColors" : "Zufällige Farben generieren",
         "Importer.Model.Advanced.SpawnMaterialOrbs" : "Material-Orbs spawnen",
         "Importer.Model.Advanced.ImagesByName" : "Bilder per Name importieren",
@@ -865,6 +868,7 @@
         "Settings.DoubleClickInterval" : "Doppelklick-Intervall",
         "Settings.ResetAllTutorials" : "Alle Tutorials zurücksetzen",
         "Settings.PreferSteamNetworking" : "Bevorzuge Steam Networking Sockets",
+        "Settings.DisableLAN" : "Deaktivieren LAN",
         "Settings.LegacyGripEquip" : "Aktiviere altes Doppel-Greifen-Ausrüsten",
         "Settings.LegacyWorldSwitcher" : "Aktiviere alten Welten-Wechseler",
         "Settings.FetchIncompatibleSessions" : "Zeige inkompatible Sitzungen",
@@ -881,6 +885,7 @@
         "Settings.LaserSmoothing.Reset" : "Laser-Einstellungen zurücksetzen",
 
         "Settings.Audio.Header" : "Audio",
+        "Settings.Audio.Master" : "Hauptlautstärke: {n,number,percent}",
         "Settings.Audio.SoundEffects" : "Soundeffekte: {n,number,percent}",
         "Settings.Audio.Multimedia" : "Multimedia: {n,number,percent}",
         "Settings.Audio.Voice" : "Stimme: {n,number,percent}",
@@ -890,7 +895,9 @@
         "Settings.Audio.NormzliationThreshold" : "Normalisierungs-Grenzwert: {n}",
         "Settings.Audio.NoiseSupression" : "Noise Suppression Filter (RNNoise)",
         "Settings.Audio.InputDevice" : "Aufnahmegerät:",
+        "Settings.Audio.OutputDevice" : "Ausgabegerät:",
         "Settings.Audio.SelectInputDevice" : "Aufnahmegerät wählen",
+        "Settings.Audio.SelectOutputDevice" : "Ausgabegerät wählen",
         "Settings.Audio.TestInput" : "Testen Sie Ihr Mikrofon:",
         "Settings.Audio.TestDescription" : "Wir geben Ihnen zur Überprüfung den Ton des gewählten Aufnahmegerätes aus",
         "Settings.Audio.StartTest" : "Mikrofontest starten",
@@ -1019,6 +1026,8 @@
         "Inspector.Texture.SwapRG" : "Tausche R und G",
         "Inspector.Texture.SwapRB" : "Tausche R und B",
         "Inspector.Texture.SwapGB" : "Tausche G und B",
+        "Inspector.Texture.AddWhiteBackground" : "Weiß Hintergrund hinzufügen",
+        "Inspector.Texture.AddBlackBackground" : "Schwarz Hintergrund hinzufügen",
         "Inspector.Texture.Hue" : "Farbton:",
         "Inspector.Texture.ShiftHue" : "Farbton verschieben",
         "Inspector.Texture.Saturation" : "Sättigung:",

--- a/fr.json
+++ b/fr.json
@@ -1,6 +1,6 @@
 {
     "localeCode" : "fr",
-    "authors" : ["Archer", "FreakyWaves", "Xqua", "brodokk"],
+    "authors" : ["Archer", "FreakyWaves", "Xqua", "brodokk", "Pr3Ci510n"],
     "messages" : 
     {
         "General.OK" : "OK",

--- a/fr.json
+++ b/fr.json
@@ -625,6 +625,7 @@
         "Importer.Model.Advanced.Tangents" : "Calculer les tangents",
         "Importer.Model.Advanced.VertexColors" : "Importer les couleurs des vertex",
         "Importer.Model.Advanced.Bones" : "Importer l'armature",
+        "Importer.Model.Advanced.Lights" : "Importer lumières",
         "Importer.Model.Advanced.TextureAlpha" : "Calculer l'alpha de la texture",
         "Importer.Model.Advanced.AlbedoColor" : "Importer la couleur de l'albédo",
         "Importer.Model.Advanced.ImportEmissive" : "Importer la couleur de l'émission",


### PR DESCRIPTION
I localized some new strings for the Czech, German, and French files.

A Czech string for "Importer.Model.Advanced.Lights" was already corrected accurately in a more recent pull request by @rampa3. I used "světlo" which is singular, but rampa3 corrected it to the plural form "světla", which is accurate. **My commit for this string should not be accepted, so accept rampa3's instead**

Most of the lines that are in this pull request are German strings. There are new strings for:
"Tooltips.Dev.ConfirmDestroySelected"
"Importer.Model.Advanced.Lights"
"Importer.Model.Advanced.SplitSubmeshes"
"Settings.DisableLAN"
"Settings.Audio.Master"
"Settings.Audio.OutputDevice"
"Settings.Audio.SelectOutputDevice"
"Inspector.Texture.AddWhiteBackground"
"Inspector.Texture.AddBlackBackground"

I also added a French string for "Importer.Model.Advanced.Lights".

The lines might be inaccurate (like the Czech string). If there is an incorrect translation for any of the lines, give feedback so it can be resolved.

EDIT: Note that this is my first time doing this because I want to help with open-source projects. I might close the pull request, but I will find a way to edit this pull request first to remove the Czech string before attempting to do that.

FINAL EDIT: I am closing and revising this pull request before sending it out again. The Czech commit from this request will be removed so it doesn't interfere with ranpa3's changes; the rest of the commits will be kept.