### PR TITLE
Added translation for Settings.Graphics.DesktopFOV, and EN store description closing list tag displacement fix

### DIFF
--- a/Store/en_description.txt
+++ b/Store/en_description.txt
@@ -67,8 +67,8 @@ Come join our diverse and creative community and bring your own uniqueness to th
 [*]Full Index Controller support with [b]finger tracking[/b]
 [*][b]Leap Motion support[/b] with full body avatars
 [*][b]Eye tracking support[/b] (Vive Pro Eye) - look direction, eye closing, pupil dilation
-[*][b]Lip tracking support[/b] (HTC Vive Facial Tracker) - track your mouth, cheeks and tongue on  your avatar or utilize the raw data[/list]
-[*][b]Haptics feedback support[/b] (bHaptics, OWO Game Suit) with avatar to avatar interactions as well as environment interactions
+[*][b]Lip tracking support[/b] (HTC Vive Facial Tracker) - track your mouth, cheeks and tongue on  your avatar or utilize the raw data
+[*][b]Haptics feedback support[/b] (bHaptics, OWO Game Suit) with avatar to avatar interactions as well as environment interactions[/list]
 
 [h2]Rapid Development[/h2]
 

--- a/cs.json
+++ b/cs.json
@@ -908,6 +908,8 @@
         "Settings.Audio.Monitoring" : "Monitorování mikrofonu:",
         "Settings.Audio.SystemDefaultOutput" : "Použít systémové výchozí",
 
+        "Settings.Graphics.DesktopFOV" : "Zorné pole pro desktopový režim",
+
         "Settings.Locale.ChangeLanguage" : "Změnit jazyk",
         "Settings.Locale.SelectLanguageHeader" : "Vyberte váš jazyk:",
 


### PR DESCRIPTION
Added Czech string for desktop mode FOV, and fixed displacement of the closing list tag in the English Steam store description. Not waiting for the issue discussion, since I looked into other languages, and this error was inherited in them from the English version in one or other form.

(this comment will be updated if more changes will be made before this pull request's merge/closing)

