### PR TITLE
Translation of the new connection string (the technical ones are left in English)

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -112,6 +112,11 @@
         "World.Connection.Connected" : "Připojeno",
         "World.Connection.SyncingInitialState" : "Synchronizuji stav světa",
 
+        "World.Connection.LNL.DirectIP" : "LNL Direct IP",
+        "World.Connection.LNL.NATPunchthrough" : "LNL NAT Punchthrough {n}",
+        "World.Connection.LNL.Relay" : "LNL Relay",
+        "World.Connection.SteamNetworkingSockets" : "Steam Networking Sockets",
+
         "World.Error.AccessDenied" : "Přístup odepřen",
         "World.Error.SecurityViolation" : "Narušení bezpečnosti",
         "World.Error.OnlyRegisteredUsers" : "Pouze registrovaní uživatelé mohou vstoupit",
@@ -125,6 +130,7 @@
         "World.Error.FailedFetchingAuthentication" : "Nenalezeny informace pro authentikaci",
         "World.Error.JoinAlreadyRequested" : "Vstup byl už jednou vyžádán",
         "World.Error.FailedConnectToRelay" : "Nelze se připojit k relé",
+        "World.Error.FailedToConnect" : "Pokus o připojení selhal",
         "World.Error.NoPort" : "Nebyl specifikován port",
         "World.Error.IncompatibleVersion" : "Nekompatibilní verze Neosu",
         "World.Error.Unknown" : "Neznámá chyba",


### PR DESCRIPTION
Translated:
- World.Error.FailedToConnect

Skipped (copied over to assure same line count as the English file (my method of quickly checking if nothing is missing)):
- World.Connection.LNL.DirectIP
- World.Connection.LNL.NATPunchthrough
- World.Connection.LNL.Relay
- World.Connection.SteamNetworkingSockets

(this comment will be updated if more changes will be made before this pull request's merge/closing)