### PR TITLE
(ja.json)セッションカウントを追加

### DIFF
--- a/ja.json
+++ b/ja.json
@@ -191,7 +191,7 @@
         "World.Indicator.Author" : "作者: {name}",
         "World.Indicator.Host" : "ホスト: {name}",
         "World.Indicator.Hosting" : "ホスティング",
-        "World.Indicator.Sessions" : "セッション",
+        "World.Indicator.Sessions" : "{n} セッション",
         "World.Indicator.Users" : "ユーザー",
         "World.Indicator.Users.None" : "(アクティブなセッションはありません)",
         "World.Indicator.Description" : "説明",


### PR DESCRIPTION
日本語環境において開いているセッションの数を表示するようになっていたかったので表示するように変更。

Changed the number of open sessions to show the number of open sessions in Japanese environment.