### PR TITLE
Translated the convert all tooltip string

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -492,6 +492,7 @@
         "Tooltip.Material.CreateCopy" : "Vytvořit kopii",
         "Tooltip.Material.Edit" : "Editovat materiál",
         "Tooltip.Material.Convert" : "Převést na...",
+        "Tooltip.Material.ConvertAll" : "Převést všechny na...",
         "Tooltip.Material.CreateNew" : "Vytvořit nový",
 
         "Tooltip.Mesh.Edit" : "Editovat mesh",


### PR DESCRIPTION
Translated:
- Tooltip.Material.ConvertAll

Translated forgoten tooltip string.

(this comment will be updated if more changes will be made before this pull request's merge/closing)