### PR TITLE
Fix for MTC avatar lobby sign locale string

### DIFF
--- a/en.json
+++ b/en.json
@@ -1281,11 +1281,10 @@
         "Tutorial.Intro.Website" : "Website",
         "Tutorial.Intro.OutroEnd" : "To support the project, join our Patreon.<br><br>Join the Discord for status updates, networking, or technical support.",
 
-        "Tutorial.MTC.Avatars" : "Avatars & Social",
+        "Tutorial.MTC.Avatars" : "Avatar Lobby",
         "Tutorial.MTC.Creation" : "Creation & Utility",
         "Tutorial.MTC.RecordingStreaming" : "Recording & Streaming",
-        "Tutorial.MTC.AvatarLobby" : "Avatar Lobby",
-
+        
         "Tutorial.Grab.MoveRotate" : "Move/Rotate held items",
         "Tutorial.Grab.Scale" : "Grab with other controller to scale",
         "Tutorial.Grab.PullToEquip" : "Pull towards you to equip",


### PR DESCRIPTION
there were some mixups about the string and which one the map was using. after this change it should be good