### PR TITLE
Mentor signal localizable strings and current translations

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -1657,6 +1657,24 @@
         "Exiting.Exiting" : "Ukončuji...",
         "Exiting.LoggingOut" : "Odhlašuji...",
 
+        "Earthenworks.MentorSignal.Title.Intro": "Cítíte se ztraceni?<br>Dobrovolní mentoři mohou pomoci",
+        "Earthenworks.MentorSignal.Title.Offline": "Cítíte se ztraceni?<br>Požádejte o pomoc na Discordu",
+        "Earthenworks.MentorSignal.Title.Requested": "Požadavek byl odeslán",
+        "Earthenworks.MentorSignal.Title.Responding": "Mentor je na cestě",
+        "Earthenworks.MentorSignal.Title.Canceled": "Tiket byl zrušen",
+        "Earthenworks.MentorSignal.Title.Completed": "Tiket byl označen jako dokončený",
+        "Earthenworks.MentorSignal.Description.Requested": "Mentoři jsou dobrovolníci - můžete být kontaktováni později, pokud nebude tiket teď vyřízen.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Responding": "<color=#88ff88><noparse={1}>{0}</color> přijal(a) tiket. Mentor by se měl brzy připojit do světa, nebo vás kontaktovat skrz seznam kontaktů na dashboardu.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Canceled": "Pokud stále potřebujete pomoc, prosíme zeptejte se na Discordu nebo ve veřejných světech. Můžete být později kontaktováni za účelem zjištění, zda stále potřebujete asistenci.",
+        "Earthenworks.MentorSignal.Description.Completed": "Pokud to je potřeba, vytvořte další tiket, nebo požádejte o pomoc na Discordu. Komunita často ráda pomůže!",
+        "Earthenworks.MentorSignal.Description.2.Disconnected": "<br><br><color=#ff8888>Tento panel ztratil připojení ke službě mentorů:</color> Panel se automaticky pokusí o znovu připojení. Zkontrolujte, zda není připojení blokováno v dialogu <color=#8888ff>Dashboard -> Domů -> Diagnostika -> Web Hosts</color>. Pokud vše ostatní selže, prosíme zrušte a znovu vytvořte tiket.<br>Pokud tento problém přetrvává, dejte nám prosíme vědět na <color=#8888ff>Discordu</color>.",
+        "Earthenworks.MentorSignal.Description.3.Full": "<br><br><color=#ff8888>Svět je aktuálně plný:</color> Požádejte hostitele o zvednutí limitu počtu hráčů/přímé pozvání mentora, nebo v koordinaci s mentorem najděte pracovní svět.",
+        "Earthenworks.MentorSignal.Description.4.No access": "<br><br><color=#ff8888>Svět není aktuálně veřejně přístupný:</color> Aby se mentor mohl do světa připojit bez přímého pozvání, je třeba aby svět byl nastaven na úroveň přístupu Registrovaní uživatelé nebo Kdokoliv, a nesmí být skryt ze seznamu relací.<br><color=#8888ff>Pokud potřebujete soukromí:</color>  Kontaktujte mentora skrz seznam kontaktů na dashboardu, aby jste jej mohli pozvat přímo.",
+        "Earthenworks.MentorSignal.Cancel.Text": "Zrušit",
+        "Earthenworks.MentorSignal.Reset.Text": "Vytvořit nový požadavek",
+        "Earthenworks.MentorSignal.Next.Text": "Požádat o pomoc",
+        "Earthenworks.MentorSignal.Discord.Text": "Připojte se na Neos Discord",
+
         "Dummy" : "Dummy"
     }
 }

--- a/de.json
+++ b/de.json
@@ -1,6 +1,6 @@
 {
     "localeCode" : "de",
-    "authors" : ["3x1t_5tyl3", "Ardes", "Avunia", "Blaze", "Bluigi", "dfgHiatus", "Elektrospy", "InnocentThief", "m1nt_", "MR-Alex", "Schwefelhexafluorid", "Tillikum"],
+    "authors" : ["3x1t_5tyl3", "Ardes", "Avunia", "Blaze", "Bluigi", "dfgHiatus", "Elektrospy", "Holy", "InnocentThief", "m1nt_", "MR-Alex", "Schwefelhexafluorid", "Tillikum"],
     "messages" :
     {
         "General.OK" : "OK",
@@ -1619,6 +1619,24 @@
         "Exiting.SavingChanges" : "Speichere Änderungen...",
         "Exiting.Exiting" : "Beenden...",
         "Exiting.LoggingOut" : "Abmelden...",
+
+        "Earthenworks.MentorSignal.Title.Intro": "Brauchst du Hilfe?<br>Freiwillige Mentoren können helfen",
+        "Earthenworks.MentorSignal.Title.Offline": "Brauchst du Hilfe?<br>Frage im Discord nach Hilfe",
+        "Earthenworks.MentorSignal.Title.Requested": "Die Anfrage wurde gesendet",
+        "Earthenworks.MentorSignal.Title.Responding": "Ein Mentor ist auf dem Weg",
+        "Earthenworks.MentorSignal.Title.Canceled": "Ticket wurde abgebrochen",
+        "Earthenworks.MentorSignal.Title.Completed": "Ticket wurde als fertig markiert",
+        "Earthenworks.MentorSignal.Description.Requested": "Mentoren sind Freiwillige, du wirst vielleicht später kontaktiert wenn das Ticket im Moment nicht beantwortet wird.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Responding": "<color=#88ff88><noparse={1}>{0}</color> hat das Ticket angenommen, der Mentor sollte bald deiner Welt beitreten oder dich per Kontaktliste benachrichtigen.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Canceled": "Wenn du immer noch Hilfe brauchst, bitte wende dich an den Discord-Server oder an öffentliche Welten. Du wirst möglicherweise später kontaktiert, um zu bestätigen ob du noch Hilfe benötigst.",
+        "Earthenworks.MentorSignal.Description.Completed": "Erstelle ruhig ein weiteres Ticket, falls mehr Hilfe benötigt wird oder frage auf Discord. Die Community hilft dir sicher gern!",
+        "Earthenworks.MentorSignal.Description.2.Disconnected": "<br><br><color=#ff8888>Dieses Panel hat Verbindung mit dem Mentor-Service verloren:</color> Das Panel wird versuchen, sich automatisch erneut zu verbinden. Prüfe, dass die Verbindung nicht blockiert wird in <color=#8888ff>Dashboard -> Home -> Debug -> Web Hosts</color>. Wenn alles scheitert, bitte brich das Ticket ab und erstelle ein neues.<br>Wenn das Problem besteht, bitte lass es uns auf <color=#8888ff>Discord</color> wissen.",
+        "Earthenworks.MentorSignal.Description.3.Full": "<br><br><color=#ff8888>Die Welt is momentan voll:</color> Frage den Host nach einer Erhöhung des Limits, lade den Mentor direkt ein, oder koordiniere mit dem Mentor, um eine Arbeitswelt zu finden.",
+        "Earthenworks.MentorSignal.Description.4.No access": "<br><br><color=#ff8888>Die Welt ist nicht öffentlich zugänglich:</color> Damit der Mentor ohne direkte Einladung beitreten kann, muss die Welt auf \"Registrierte Benutzer\" oder \"Jeder\" gesetzt werden und nicht von der Sitzungs-Liste versteckt sein.<br><color=#8888ff>Wenn du Privatsphäre brauchst:</color> Kontaktiere den Mentor durch die Kontaktliste um ihn direkt einzuladen.",
+        "Earthenworks.MentorSignal.Cancel.Text": "Abbrechen",
+        "Earthenworks.MentorSignal.Reset.Text": "Weiteres erstellen",
+        "Earthenworks.MentorSignal.Next.Text": "Hilfe bekommen",
+        "Earthenworks.MentorSignal.Discord.Text": "Tritt dem Neos Discord bei",
 
         "Dummy" : "Dummy"
     }

--- a/en.json
+++ b/en.json
@@ -1683,6 +1683,24 @@
         "Exiting.Exiting" : "Exiting...",
         "Exiting.LoggingOut" : "Logging out...",
 
+        "Earthenworks.MentorSignal.Title.Intro": "Feeling Lost?<br>Mentor Volunteers Can Help",
+        "Earthenworks.MentorSignal.Title.Offline": "Feeling Lost?<br>Ask in the Discord for help",
+        "Earthenworks.MentorSignal.Title.Requested": "The Request Has Gone Out",
+        "Earthenworks.MentorSignal.Title.Responding": "A Mentor Is On The Way",
+        "Earthenworks.MentorSignal.Title.Canceled": "Ticket Was Canceled",
+        "Earthenworks.MentorSignal.Title.Completed": "Ticket Was Marked As Completed",
+        "Earthenworks.MentorSignal.Description.Requested": "Mentors are volunteers, you may be contacted later if the ticket doesn't get answered at this time.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Responding": "<color=#88ff88><noparse={1}>{0}</color> has claimed the ticket, soon they should either join the world, or contact you through the Contacts list.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Canceled": "If you still need help, please reach out to the Discord or in public worlds. You may be contacted later to see if you still need assistance.",
+        "Earthenworks.MentorSignal.Description.Completed": "Feel free to create another ticket if required, or ask for help on the Discord. The community is often happy to help!",
+        "Earthenworks.MentorSignal.Description.2.Disconnected": "<br><br><color=#ff8888>This panel has lost connection with the mentor service:</color> The panel will attempt to reconnect automatically. Check to ensure the connection is not blocked in <color=#8888ff>Dashboard -> Home -> Debug -> Web Hosts</color>. If all else fails, please cancel and re-create the ticket.<br>If this problem persists please let us known on the <color=#8888ff>Discord</color>.",
+        "Earthenworks.MentorSignal.Description.3.Full": "<br><br><color=#ff8888>The world is currently full:</color> Ask the host to raise the player limit, invite the mentor directly, or coordinate with the mentor to find a work world.",
+        "Earthenworks.MentorSignal.Description.4.No access": "<br><br><color=#ff8888>The world is not publically accessible:</color> For the mentor to join without an direct invitation the world must be Registered or Anyone, and must not be hidden from the session list.<br><color=#8888ff>If you need privacy:</color> Contact the mentor through the Contacts list so they can be invited directly.",
+        "Earthenworks.MentorSignal.Cancel.Text": "Cancel",
+        "Earthenworks.MentorSignal.Reset.Text": "Create Another",
+        "Earthenworks.MentorSignal.Next.Text": "Get Help",
+        "Earthenworks.MentorSignal.Discord.Text": "Join the Neos Discord",
+
         "Dummy" : "Dummy"
     }
 }

--- a/en.json
+++ b/en.json
@@ -1,6 +1,6 @@
 {
     "localeCode" : "en",
-    "authors" : ["Frooxius", "Enverex", "rampa_3", "Melnus", "dfgHiatus"],
+    "authors" : ["Frooxius", "Enverex", "rampa_3", "Melnus", "dfgHiatus", "Earthmark"],
     "messages" :
     {
         "General.OK" : "OK",

--- a/fr.json
+++ b/fr.json
@@ -1381,6 +1381,24 @@
         "Exiting.Exiting" : "Au revoir!",
         "Exiting.LoggingOut" : "En déconnexion",
 
+        "Earthenworks.MentorSignal.Title.Intro": "Besoin D'aide?<br>Des Mentors volontaires peuvent vous aider!",
+        "Earthenworks.MentorSignal.Title.Offline": "Besoin D'aide?<br>Posez vos questions dans notre discord!",
+        "Earthenworks.MentorSignal.Title.Requested": "Votre demande a été envoyée!",
+        "Earthenworks.MentorSignal.Title.Responding": "Un Mentor est en chemin...",
+        "Earthenworks.MentorSignal.Title.Canceled": "Ticket Annulé.",
+        "Earthenworks.MentorSignal.Title.Completed": "Ticket marqué comme complété",
+        "Earthenworks.MentorSignal.Description.Requested": "Les mentors sont volontaires, Il est possible qu'ils vous contactent plus tard si votre ticket n'est pas traité dans les prochaines minutes.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Responding": "<color=#88ff88><noparse={1}>{0}</color> a récupéré votre ticket, dans peut de temps, ce mentor rejoindra votre monde ou vous enverra une demande de contact dans peu de temps.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Canceled": "Si vous avez encore besoin d'aide, n'hésitez pas à demander plus d'aide sur Discord ou dans un monde public. Il est possible que des mentors vous contactent plus tard dans le cas où vous avez besoin d'un peu plus d'aides.",
+        "Earthenworks.MentorSignal.Description.Completed": "N'hésitez pas à créer un nouveau ticket si besoin, ou demander de l'aide sur Discord! La plupart de la communauté adore aider ceux qui en on besoin!",
+        "Earthenworks.MentorSignal.Description.2.Disconnected": "<br><br><color=#ff8888>La connexion au service Mentor fut perdue:</color> ce panel tenté de se reconnecter automatiquement. Vérifiez que votre connexion n'est pas bloquée dans <color=#8888ff>Dashboard -> Home -> Debug -> Web Hosts</color>. Si cela ne fonctionne pas, veuillez annuler votre ticket, et renouveler la création de celui-ci.<br>Si le problème persisté veuillez nous le faire savoir sur <color=#8888ff>Discord</color>.",
+        "Earthenworks.MentorSignal.Description.3.Full": "<br><br><color=#ff8888>Le monde a atteint sa capacité maximale:</color> Demandez au créateur du monde d'augmenter la limite de joueur, invitez le mentor directement ou communiquez avec le mentor pour trouver un monde de travail.",
+        "Earthenworks.MentorSignal.Description.4.No access": "<br><br><color=#ff8888>Le monde n'est pas accessible au public:</color> Pour que le mentor vous rejoignes sans invitation directe, le monde doit être enregistré ou joignable par tout le monde, et ne dois pas être caché dans la liste des sessions.<br><color=#8888ff>Si vous avez besoin d'intimité:</color> Contactez le mentor via votre liste de contacts pour qu'il/elle puisse être invités.",
+        "Earthenworks.MentorSignal.Cancel.Text": "Annuler",
+        "Earthenworks.MentorSignal.Reset.Text": "Créer un nouveau ticket",
+        "Earthenworks.MentorSignal.Next.Text": "Demander de l'aide",
+        "Earthenworks.MentorSignal.Discord.Text": "Rejoindre le discord de Neos",
+
         "Dummy" : "Dummy"
     }
 }

--- a/fr.json
+++ b/fr.json
@@ -1,6 +1,6 @@
 {
     "localeCode" : "fr",
-    "authors" : ["Archer", "FreakyWaves", "Xqua", "brodokk"],
+    "authors" : ["Archer", "FreakyWaves", "Xqua", "brodokk", "Sopra"],
     "messages" : 
     {
         "General.OK" : "OK",

--- a/ja.json
+++ b/ja.json
@@ -1682,6 +1682,24 @@
         "Exiting.Exiting" : "終了中...",
         "Exiting.LoggingOut" : "ログアウト中...",
 
+        "Earthenworks.MentorSignal.Title.Intro": "助けが必要ですか？<br>メンターにヘルプを求めることが出来ます",
+        "Earthenworks.MentorSignal.Title.Offline": "助けが必要ですか？<br>Discordで質問してみましょう",
+        "Earthenworks.MentorSignal.Title.Requested": "ヘルプを呼びました！",
+        "Earthenworks.MentorSignal.Title.Responding": "メンターがもうすぐ来ます",
+        "Earthenworks.MentorSignal.Title.Canceled": "ヘルプをキャンセルしました",
+        "Earthenworks.MentorSignal.Title.Completed": "要求が完了しました",
+        "Earthenworks.MentorSignal.Description.Requested": "メンターはボランティアです、 すぐには誰も来られないかもしれません。 その場合は後日連絡が来ることがあります。 {2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Responding": "<color=#88ff88><noparse={1}>{0}</color> がリクエストを確認しました。 すぐにワールドに参加して来るか、 「フレンド」からメッセージが飛んでくるかもしれません。 確認してみてください。 {2} {3} {4}",
+        "Earthenworks.MentorSignal.Description.Canceled": "まだヘルプが必要な場合は、Discordや パブリックワールドで改めて声をかけてください。 後日、ヘルプが必要かどうかの連絡があるかもしれません。",
+        "Earthenworks.MentorSignal.Description.Completed": "必要に応じて改めてヘルプを求めたり、 Discordで助けを求めてください。 コミュニティが喜んでお手伝いいたします！",
+        "Earthenworks.MentorSignal.Description.2.Disconnected": "<br><br><color=#ff8888>現在、メンターサービスとの接続が切れているようです:</color> 自動的に再接続を試みます。<color=#8888ff>ダッシュメニュー -> ホーム -> デバッグ -> Web Hosts</color>で接続がブロックされていないか確認してください。<br>もしブロックしていないのにこの表示が 出る場合は、<color=#8888ff>Discord</color>で知らせてください。",
+        "Earthenworks.MentorSignal.Description.3.Full": "<br><br><color=#ff8888>このワールドは満員のようです。</color> 可能であればホストに最大ユーザー数を上げてもらうか、メンターを直接招待してください。 あるいは、メンターと別ワールドを開くことを検討してください。",
+        "Earthenworks.MentorSignal.Description.4.No access": "<br><br><color=#ff8888>このワールドは誰でも入れないようになっています （またはリストに表示されていません） :</color> もし応答したメンターがフレンドでない場合は、「このワールドに入れる人」を「登録ユーザー」または「誰でも」に設定してください。<br><color=#8888ff>セキュリティ上の 問題がある場合 (アバターの初期セットアップなど):</color> 「セッション」から「セッションリストに表示しない」にチェックを入れることで メンター以外はアクセスが困難になります。 もしくはメンターとフレンドになり 直接招待することもできます。",
+        "Earthenworks.MentorSignal.Cancel.Text": "キャンセル",
+        "Earthenworks.MentorSignal.Reset.Text": "最初に戻る",
+        "Earthenworks.MentorSignal.Next.Text": "ヘルプを呼ぶ",
+        "Earthenworks.MentorSignal.Discord.Text": "Neos Discord に参加しましょう！",
+
         "Dummy" : "ダミー"
     }
 }

--- a/ko.json
+++ b/ko.json
@@ -1629,6 +1629,24 @@
         "World.Category.Random" : "무작위",
         "World.SortParameter.Random" : "무작위",
 
+        "Earthenworks.MentorSignal.Title.Intro": "도움이 필요하신가요?<br>멘토들이 도움을 드릴 수 있습니다.",
+        "Earthenworks.MentorSignal.Title.Offline": "도움이 필요하신가요?<br>디스코드에서 도움을 요청해 보세요",
+        "Earthenworks.MentorSignal.Title.Requested": "티켓이 전송되었습니다",
+        "Earthenworks.MentorSignal.Title.Responding": "멘토가 곧 도착합니다",
+        "Earthenworks.MentorSignal.Title.Canceled": "티켓이 취소되었습니다",
+        "Earthenworks.MentorSignal.Title.Completed": "티켓이 완료된 것으로 처리되었습니다",
+        "Earthenworks.MentorSignal.Description.Requested": "멘토는 자원봉사자 입니다, 지금 요청이 수락되지 않더라도 나중에 연락을 받으실 수 있습니다.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Responding": "<color=#88ff88><noparse={1}>{0}</color> 님께서 요청을 수락하셨습니다, 곧 월드로 접속하거나, 연락처를 통해 메시지를 보낼 것입니다.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Canceled": "아직 도움이 필요하다면, 디스코드나 퍼블릭 월드에서 도움을 요청하세요. 나중에 멘토로부터 아직 도움이 필요한지 묻는 연락이 올 수 있습니다.",
+        "Earthenworks.MentorSignal.Description.Completed": "필요한 경우 언제든 새 티켓을 생성하거나, 디스코드에서 도움을 요청하세요. 커뮤니티 멤버들이 정성껏 도와드릴 것입니다!",
+        "Earthenworks.MentorSignal.Description.2.Disconnected": "<br><br><color=#ff8888>해당 패널은 멘토 서비스와 연결이 끊긴 상태입니다:</color> 자동으로 재접속을 시도합니다. 대시보드 -> 홈 -> 디버그 -> 허가된 호스트에서 연결이 차단되지는 않았는지 확인해주세요. 모든 접속 시도가 실패했다면, 요청을 취소하고 새 티켓을 생성해주세요.<br>해당 문제가 지속된다면 <color=#8888ff>디스코드</color>에서 알려주세요.",
+        "Earthenworks.MentorSignal.Description.3.Full": "<br><br><color=#ff8888>월드가 최대 인원에 도달했습니다:</color> 호스트에게 인원 증가를 요청하거나, 멘토를 직접 초대하거나, 또는 멘토와 함께 작업이 가능한 월드를 찾아보세요.",
+        "Earthenworks.MentorSignal.Description.4.No access": "<br><br><color=#ff8888>월드가 공개적으로 접근할 수 없는 상태입니다:</color> 직접 초대하지 않고도 멘토가 들어오려면 월드의 접근 권한이 가입된 사용자나 누구나로 설정되어 있어야 하며, 세션 리스트에서 숨겨져있지 않아야 합니다.<br><color=#8888ff>프라이버시가 필요할 경우:</color> 연락처를 통해 멘토와 연락한 후 직접 초대를 보내주세요.",
+        "Earthenworks.MentorSignal.Cancel.Text": "취소",
+        "Earthenworks.MentorSignal.Reset.Text": "새 티켓 생성",
+        "Earthenworks.MentorSignal.Next.Text": "도움 요청",
+        "Earthenworks.MentorSignal.Discord.Text": "네오스 디스코드 참여",
+
         "Dummy": "더미"
     }
 }

--- a/ru.json
+++ b/ru.json
@@ -1683,6 +1683,24 @@
         "Exiting.Exiting" : "Выход...",
         "Exiting.LoggingOut" : "Выход с аккаунта...",
 
+        "Earthenworks.MentorSignal.Title.Intro": "Потерялись?<br>Добровольцы-Менторы могут помочь",
+        "Earthenworks.MentorSignal.Title.Offline": "Потерялись?<br>Спросите совета в Discord",
+        "Earthenworks.MentorSignal.Title.Requested": "Запрос отправлен",
+        "Earthenworks.MentorSignal.Title.Responding": "Ментор спешит на помощь",
+        "Earthenworks.MentorSignal.Title.Canceled": "Заявка отменена",
+        "Earthenworks.MentorSignal.Title.Completed": "Заявка помечена как выполненная",
+        "Earthenworks.MentorSignal.Description.Requested": "Менторы - это добровольцы, с Вами могут связаться позже если на заявку сейчас никто не ответит.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Responding": "<color=#88ff88><noparse={1}>{0}</color> принял заявку, вскоре он(а) подключится к сессии, или свяжется с Вами через список Контактов.{2}{3}{4}",
+        "Earthenworks.MentorSignal.Description.Canceled": "Если Вам всё ещё нужна помощь, попробуйте задать вопрос в Discord или в публичных сессиях. С Вами могут связаться позже, если ваш вопрос ещё не будет решен.",
+        "Earthenworks.MentorSignal.Description.Completed": "Не стесняйтесь завести новую заявку, или попросите помощи в Discord. Сообщество обычно готово помочь!",
+        "Earthenworks.MentorSignal.Description.2.Disconnected": "<br><br><color=#ff8888>Эта панель потеряла связь с сервисом заявок:</color> Панель попытается переподключиться автоматически. Проверьте что соединение не заблокировано в <color=#8888ff>Дэш -> Дом -> Отладка -> Web Hosts</color>. Если ничего не помогает, попробуйте отменить и пересоздать заявку.<br>Если проблема сохраняется, сообщите нам через <color=#8888ff>Discord</color>.",
+        "Earthenworks.MentorSignal.Description.3.Full": "<br><br><color=#ff8888>Сессия в настоящий момент заполнена:</color> Попросите владельца сессии поднять лимит пользователей, пригласите ментора напрямую, или договоритесь с ментором встретиться в другой сессии.",
+        "Earthenworks.MentorSignal.Description.4.No access": "<br><br><color=#ff8888>Эта сессия недоступна для публики:</color> Чтобы ментор мог подключиться без прямого приглашения, доступ в сессию должен быть Все или Зарегистрированные, и сессия не должна быть спрятана из списка сессий.<br><color=#8888ff>Если Вам нужна приватность:</color> Свяжитесь с ментором через список Контактов чтобы пригласить его(её) напрямую.",
+        "Earthenworks.MentorSignal.Cancel.Text": "Отменить",
+        "Earthenworks.MentorSignal.Reset.Text": "Создать ещё",
+        "Earthenworks.MentorSignal.Next.Text": "Получить помощь",
+        "Earthenworks.MentorSignal.Discord.Text": "Подключиться к Neos Discord",
+
         "Dummy" : "Dummy"
     }
 }


### PR DESCRIPTION
Added mentor signal strings, and the current translations for those strings. This also removed the strings that are not longer part of the panel, such as the connection request and the second page of the panel.