### PR TITLE
Translated the system default language string

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -972,6 +972,7 @@
 
         "Settings.Locale.ChangeLanguage" : "Změnit jazyk",
         "Settings.Locale.SelectLanguageHeader" : "Vyberte váš jazyk:",
+        "Settings.Locale.DefaultLanguage" : "Systémový výchozí",
 
         "Settings.Save" : "Uložit nastavení",
 


### PR DESCRIPTION
Translated:
 - Settings.Locale.DefaultLanguage

(this comment will be updated if more changes will be made before this pull request's merge/closing)