### PR TITLE
feat(tools): new strings for grabbable setter tip

### DIFF
--- a/en.json
+++ b/en.json
@@ -500,6 +500,8 @@
 
         "Tooltip.GrabbableSetter.Scalable" : "Set Scalable",
         "Tooltip.GrabbableSetter.NonScalable" : "Set Non-scalable",
+        "Tooltip.GrabbableSetter.ApplyToRoot" : "Set Apply to Root",
+        "Tooltip.GrabbableSetter.AppyToHit" : "Set Apply to Hit",
 
         "Tooltip.CharacterCollider.MarkGrippable" : "Mark Grippable",
         "Tooltip.CharacterCollider.DontMarkGrippable" : "Don't Mark Grippable",


### PR DESCRIPTION
Needs: https://github.com/Neos-Metaverse/NeosFramework/pull/41

Some notes from, there to help folks:

This adds an ApplyToObjectRoot option to the GrabbableSetterTip, it defaults on True/On.

The option controls where the grabbable is applied to in an operation:
- When set to true/on it applies it to the object root.
- When set to false/off it will apply to the object which is directly hit by the tooltip.