### PR TITLE
Translated the invalid address error

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -150,6 +150,7 @@
         "World.Error.JoinAlreadyRequested" : "Vstup byl už jednou vyžádán",
         "World.Error.FailedConnectToRelay" : "Nelze se připojit k relé",
         "World.Error.FailedToConnect" : "Pokus o připojení selhal",
+        "World.Error.InvalidAddress": "Neplatná adresa",
         "World.Error.NoPort" : "Nebyl specifikován port",
         "World.Error.IncompatibleVersion" : "Nekompatibilní verze Neosu",
         "World.Error.Unknown" : "Neznámá chyba",


### PR DESCRIPTION
Translated:
 - World.Error.InvalidAddress

(this comment will be updated if more changes will be made before this pull request's merge/closing)

Note: Expect slower translation update cycle from now onward, since I have to balance translating with studying at university.