### PR TITLE
Translated OBS websocket plugin web page open reason and tokens disabled informational string

### DIFF
--- a/cs.json
+++ b/cs.json
@@ -438,6 +438,7 @@
         "Contacts.BanFromCurrentWorld" : "Zabanovat z aktuálního světa",
         "Contacts.UnbanFromCurrentWorld" : "Odbanovat z aktuálního světa",
         "Contacts.RecordingVoiceMessage" : "Nahrávám hlasovou zprávu...",
+        "Contacts.TokensDisabled": "Funkcionalita týkající se NCR/KFC/CDFT je v tomto buildu zakázána.",
 
         "Contacts.InSession" : "Ve světě {name}",
         "Contacts.InPrivate" : "V privátním světě",

--- a/cs.json
+++ b/cs.json
@@ -918,6 +918,7 @@
         "CameraControl.OBS.DroppedFrames" : "Zahozeno snímků: {n}",
         "CameraCOntrol.OBS.Live" : "ŽIVĚ",
         "CameraCOntrol.OBS.Recording" : "REC",
+        "CameraControl.OBS.OpenInstallerReason": "Tato webová stránka vám umožní stáhnout OBS websocket plugin",
 
         "CameraControl.OBS.Streaming.Start" : "Spustit streamování",
         "CameraControl.OBS.Streaming.Starting" : "Spouštím streamování...",


### PR DESCRIPTION
Translated:
 - CameraControl.OBS.OpenInstallerReason
 - Contacts.TokensDisabled

(this comment will be updated if more changes will be made before this pull request's merge/closing)

Note: Expect slower translation update cycle from now onward, since I have to balance translating with studying at university.